### PR TITLE
add clangformat 18 ubuntu image

### DIFF
--- a/.github/workflows/build-sil-kit-ci-image.yaml
+++ b/.github/workflows/build-sil-kit-ci-image.yaml
@@ -108,3 +108,31 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  clangformat-ubuntu-2204:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: "ghcr.io"
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: "ghcr.io/MariusBgm/sil-kit-ci-clangformat-22.04"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./containers/ci-clangformat-ubuntu/
+          file: ./containers/ci-clangformat-ubuntu/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/containers/ci-clangformat-ubuntu/Dockerfile
+++ b/containers/ci-clangformat-ubuntu/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 RUN \
         apt-get update \
         && \
-        apt-get install -y --no-install-recommends wget \
+        apt-get install -y wget ca-certificates \
         && \
         wget https://apt.llvm.org/llvm.sh -P /tmp/ \
         && \

--- a/containers/ci-clangformat-ubuntu/Dockerfile
+++ b/containers/ci-clangformat-ubuntu/Dockerfile
@@ -11,6 +11,7 @@ RUN \
         apt-get update \
         && \
         apt-get install -y \
+            git \
             wget \
             gnupg2 \
             software-properties-common \

--- a/containers/ci-clangformat-ubuntu/Dockerfile
+++ b/containers/ci-clangformat-ubuntu/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 RUN \
         apt-get update \
         && \
-        apt-get install -y wget ca-certificates \
+        apt-get install -y wget ca-certificates lsb_release add-apt-repository gpg build-essentials\
         && \
         wget https://apt.llvm.org/llvm.sh -P /tmp/ \
         && \
@@ -20,7 +20,7 @@ RUN \
         && \
         apt update \
         && \
-        apt install -y --no-install-recommends --no-install-suggests clang-format-18 \
+        apt install -y clang-format-18 \
         && \
         apt-get clean
 

--- a/containers/ci-clangformat-ubuntu/Dockerfile
+++ b/containers/ci-clangformat-ubuntu/Dockerfile
@@ -10,15 +10,17 @@ ENV LANG C.UTF-8
 RUN \
         apt-get update \
         && \
+        apt-get install -y --no-install-recommends wget \
+        && \
         wget https://apt.llvm.org/llvm.sh -P /tmp/ \
         && \
         chmod +x /tmp/llvm.sh \
         && \
-        sudo /tmp/llvm.sh 18 \
+        /tmp/llvm.sh 18 \
         && \
-        sudo apt update \
+        apt update \
         && \
-        sudo apt install -y --no-install-recommends --no-install-suggests clang-format-18 \
+        apt install -y --no-install-recommends --no-install-suggests clang-format-18 \
         && \
         apt-get clean
 

--- a/containers/ci-clangformat-ubuntu/Dockerfile
+++ b/containers/ci-clangformat-ubuntu/Dockerfile
@@ -1,0 +1,24 @@
+ARG UBUNTU_VERSION="22.04"
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ENV TZ "Europe/Berlin"
+ENV DEBIAN_FRONTEND "noninteractive"
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+RUN \
+        apt-get update \
+        && \
+        wget https://apt.llvm.org/llvm.sh -P /tmp/ \
+        && \
+        chmod +x /tmp/llvm.sh \
+        && \
+        sudo /tmp/llvm.sh 18 \
+        && \
+        sudo apt update \
+        && \
+        sudo apt install -y --no-install-recommends --no-install-suggests clang-format-18 \
+        && \
+        apt-get clean
+

--- a/containers/ci-clangformat-ubuntu/Dockerfile
+++ b/containers/ci-clangformat-ubuntu/Dockerfile
@@ -10,7 +10,12 @@ ENV LANG C.UTF-8
 RUN \
         apt-get update \
         && \
-        apt-get install -y wget ca-certificates lsb_release add-apt-repository gpg build-essentials\
+        apt-get install -y \
+            wget \
+            gnupg2 \
+            software-properties-common \
+            lsb-base \
+            lsb-release \
         && \
         wget https://apt.llvm.org/llvm.sh -P /tmp/ \
         && \


### PR DESCRIPTION
add llvm / clang 18 to an ubuntu 22.04 base system. this is for running clang-format version 18 in our CI